### PR TITLE
Backport upstream change to macOS library check

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -134,6 +134,7 @@ module Omnibus
       /Tcl$/,
       /Cocoa$/,
       /Carbon$/,
+      /Foundation/,
       /IOKit$/,
       /Tk$/,
       /libutil\.dylib/,


### PR DESCRIPTION
This is necessary to build Ruby v2.5.1 on macOS.

see: https://github.com/chef/omnibus/commit/80fbe36410aa07c5092fc5c4d5dccdd75f2c760e